### PR TITLE
Add cors to allow local frontend to connect to api endpoints

### DIFF
--- a/ProductMicroservice/Program.cs
+++ b/ProductMicroservice/Program.cs
@@ -22,7 +22,21 @@ builder.Services.AddGraphQLServer()
     .AddFiltering()
     .AddSorting();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowSpecificOrigin",
+        builder =>
+        {
+            builder
+            .WithOrigins("http://localhost:3000") // Allow only this origin
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+        });
+});
+
 var app = builder.Build();
+
+app.UseCors("AllowSpecificOrigin");
 
 app.MapGraphQL();
 


### PR DESCRIPTION
In order to get the react frontend to be able to connect to the backend, I needed to add a cors to allow localhost at the port used to to run the react project, 3000.